### PR TITLE
Feat/create count states

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,29 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# Top-most EditorConfig file
+root = true
+
+# Default settings for all files
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+# Override for TypeScript and JavaScript files
+[*.{ts,tsx,js,jsx}]
+indent_size = 2
+
+# Override for JSON and YAML files
+[*.{json,yml,yaml}]
+indent_size = 2
+
+# Override for Markdown files
+[*.md]
+trim_trailing_whitespace = false
+
+# Override for CSS, SCSS, and LESS files
+[*.{css,scss,less}]
+indent_size = 2

--- a/src/Controller/controllerGlobal.tsx
+++ b/src/Controller/controllerGlobal.tsx
@@ -47,10 +47,8 @@ export function isWithinOneYear(date1: any, date2: any, dateValid?: any) {
 }
 
 export function isDateTerm(dateValid?: any) {
-
-
   const dateNow = Date.now();
-  const dateValidTerm = new Date(dateValid).getTime()
+  const dateValidTerm = new Date(dateValid).getTime();
 
   return dateValidTerm >= dateNow; // Verifica se está dentro de um ano
 }
@@ -91,7 +89,6 @@ export const getStatusList = () => {
   const status = [
     { id: Status.APPROVED, name: "Aprovado" },
     { id: Status.PENDING, name: "Pendente de análise" },
-    { id: Status.PENDING_DOCUMENTATION, name: "Pendente de documentação" },
     { id: Status.PENDING_TERM, name: "Pendente de termo" },
   ];
   return status;
@@ -126,7 +123,6 @@ export const Status = {
   PENDING: "PENDING",
   REPROVED: "REPROVED",
   PENDING_TERM: "PENDING_TERM",
-  PENDING_DOCUMENTATION: "PENDING_DOCUMENTATION",
   CANCELED: "CANCELED",
 };
 
@@ -135,7 +131,6 @@ export const StatusEnum: any = {
   PENDING: "Pendente",
   REPROVED: "Reprovado",
   PENDING_TERM: "Pend. de termo",
-  PENDING_DOCUMENTATION: "Pend. de documentação",
 };
 
 export const ROLE = {

--- a/src/Pages/Classroom/ClassroomOne/index.tsx
+++ b/src/Pages/Classroom/ClassroomOne/index.tsx
@@ -31,6 +31,9 @@ import ModalChange from "./ModalChangeClaassroom";
 import color from "../../../Styles/colors";
 
 import { requestChartFrequency } from "../../../Services/Chart/request";
+import { StateCard } from "../../../Types/states-cards";
+import { requestCountStates } from "../../../Services/Classroom/request";
+import CardQuant from "../../../Components/Chart/CardQuant";
 
 const ClassroomOne = () => {
   return (
@@ -47,6 +50,7 @@ const ClassroomOnePage = () => {
   const { data: classroom } = useFetchRequestClassroomOne(parseInt(id!));
   const [edit, setEdit] = useState(false);
   const [visible, setVisible] = useState(false);
+  const [cards, setCards] = useState<StateCard[]>([]);
 
   const [chartData, setChartData] = useState({});
 
@@ -92,7 +96,13 @@ const ClassroomOnePage = () => {
       }
     };
 
+    const cardsData = async () => {
+      const counts = await requestCountStates(classroom?.id);
+      setCards(counts);
+    };
+
     fetchData();
+    cardsData();
   }, [classroom?.id]);
 
   const propsAplication = useContext(
@@ -233,6 +243,24 @@ const ClassroomOnePage = () => {
             icon={report}
           />
         </div>
+      </div>
+
+      <div className="grid">
+        {cards.map((item) => (
+          <div className="col-12 md:col-4 lg:col-2">
+            <CardQuant
+              title={item.status}
+              quant={item.number}
+              color={
+                item.status === "Aprovados"
+                  ? "orange"
+                  : item.status === "Pendentes"
+                  ? "blue"
+                  : "navy_blue"
+              }
+            />
+          </div>
+        ))}
       </div>
 
       <div

--- a/src/Services/Classroom/request.tsx
+++ b/src/Services/Classroom/request.tsx
@@ -65,7 +65,10 @@ export const requestClassroomReport = (id: number) => {
     });
 };
 
-export const requestUpdateClassroom = (id: number, data: { name: string, status: string }) => {
+export const requestUpdateClassroom = (
+  id: number,
+  data: { name: string; status: string }
+) => {
   let path = "/classroom/";
   return http
     .put(path + id, data)
@@ -141,5 +144,18 @@ export const requestDeleteClassroom = (id: number) => {
       }
       alert(err.response.message);
       throw err;
+    });
+};
+
+export const requestCountStates = (id: number) => {
+  let path = "/classroom-bff/count-states";
+  return http
+    .get(path, { params: { idClassroom: id } })
+    .then((response) => response.data)
+    .catch((err) => {
+      if (err.response.status === 401) {
+        logout();
+        window.location.reload();
+      }
     });
 };

--- a/src/Types/states-cards.ts
+++ b/src/Types/states-cards.ts
@@ -1,0 +1,1 @@
+export type StateCard = { number: number; status: string };


### PR DESCRIPTION
## Descrição

Finalizada a  criação de novos cards, exibindo os estados e as quantidades de alunos associados a cada um. A funcionalidade foi completada com sucesso, permitindo uma visualização clara e precisa dos dados de alunos por estado.

## Alterações realizadas

- Criação dos cards para cada estado.
- Inclusão das quantidades de alunos associadas a cada estado.
- Ajustes no layout e na estrutura para garantir a usabilidade e clareza na visualização.

## Resultado

![416841839-177d2b07-58b4-4c43-8296-04e374f07c58](https://github.com/user-attachments/assets/1406fa93-c69c-434d-a841-537d2217d057)

