### PR TITLE
chore(dependencies): remove type dependencies and move to devDependen…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,11 +11,6 @@
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
-        "@types/jest": "^27.5.2",
-        "@types/node": "^16.18.70",
-        "@types/pdfmake": "^0.2.9",
-        "@types/react": "^18.2.47",
-        "@types/react-dom": "^18.2.18",
         "axios": "^1.6.7",
         "buffer": "^6.0.3",
         "chart.js": "^4.4.7",
@@ -44,7 +39,12 @@
         "yup": "^1.3.3"
       },
       "devDependencies": {
-        "@types/file-saver": "^2.0.7"
+        "@types/file-saver": "^2.0.7",
+        "@types/jest": "^27.5.2",
+        "@types/node": "^16.18.70",
+        "@types/pdfmake": "^0.2.9",
+        "@types/react": "^18.2.47",
+        "@types/react-dom": "^18.2.18"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -4315,17 +4315,21 @@
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="
     },
     "node_modules/@types/pdfkit": {
-      "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/@types/pdfkit/-/pdfkit-0.13.4.tgz",
-      "integrity": "sha512-ixGNDHYJCCKuamY305wbfYSphZ2WPe8FPkjn8oF4fHV+PgPV4V+hecPh2VOS2h4RNtpSB3zQcR4sCpNvvrEb1A==",
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/@types/pdfkit/-/pdfkit-0.13.9.tgz",
+      "integrity": "sha512-RDG8Yb1zT7I01FfpwK7nMSA433XWpblMqSCtA5vJlSyavWZb303HUYPCel6JTiDDFqwGLvtAnYbH8N/e0Cb89g==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/pdfmake": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@types/pdfmake/-/pdfmake-0.2.9.tgz",
-      "integrity": "sha512-uLDKEH3A1fnCd/qXYJB2OnKkkjfdC1oc6HYVYBKxsyN1UsJL/8Lt67T6WFo3umkL+5Zd74M2IYcOf5kwwd9x9w==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@types/pdfmake/-/pdfmake-0.2.11.tgz",
+      "integrity": "sha512-gglgMQhnG6C2kco13DJlvokqTxL+XKxHwCejElH8fSCNF9ZCkRK6Mzo011jQ0zuug+YlIgn6BpcpZrARyWdW3Q==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*",
         "@types/pdfkit": "*"

--- a/package.json
+++ b/package.json
@@ -3,14 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@testing-library/jest-dom": "^5.17.0",
-    "@testing-library/react": "^13.4.0",
-    "@testing-library/user-event": "^13.5.0",
-    "@types/jest": "^27.5.2",
-    "@types/node": "^16.18.70",
-    "@types/pdfmake": "^0.2.9",
-    "@types/react": "^18.2.47",
-    "@types/react-dom": "^18.2.18",
     "axios": "^1.6.7",
     "buffer": "^6.0.3",
     "chart.js": "^4.4.7",
@@ -36,7 +28,10 @@
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4",
     "xlsx": "^0.18.5",
-    "yup": "^1.3.3"
+    "yup": "^1.3.3",
+    "@testing-library/jest-dom": "^5.17.0",
+    "@testing-library/react": "^13.4.0",
+    "@testing-library/user-event": "^13.5.0"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -63,6 +58,11 @@
     ]
   },
   "devDependencies": {
-    "@types/file-saver": "^2.0.7"
+    "@types/file-saver": "^2.0.7",
+    "@types/jest": "^27.5.2",
+    "@types/node": "^16.18.70",
+    "@types/pdfmake": "^0.2.9",
+    "@types/react": "^18.2.47",
+    "@types/react-dom": "^18.2.18"
   }
 }


### PR DESCRIPTION
## Chore: Ajuste de Dependências  

### Alterações  
- Removida a tipagem das dependências do escopo principal  
- Movida para `devDependencies`  

### Motivo  
- Dependências de tipagem são necessárias apenas no desenvolvimento  
- Reduz o tamanho do bundle de produção  

### Impacto  
- Nenhuma alteração no comportamento da aplicação  
- Melhor organização das dependências  
